### PR TITLE
Externe MP4-Streams jetzt möglich

### DIFF
--- a/lib/rex_plyr.php
+++ b/lib/rex_plyr.php
@@ -94,6 +94,16 @@ class rex_plyr
         return $vimeoID;
     }
 
+    public static function checkExternalMp4($url)
+    {
+        $checkSource = get_headers($url, 1);
+        if(isset($checkSource['Content-Type']) && $checkSource['Content-Type'] === 'video/mp4')
+        {
+            return true;
+        }
+        return false;
+    }
+    
     public static function outputMedia($url,$controls=NULL, $poster=NULL)
     {
 
@@ -114,7 +124,7 @@ class rex_plyr
             {
                 $out = '<div class="rex-plyr" data-plyr-provider="vimeo" data-plyr-embed-id="' . $player->getVimeoId($link) . '"'.$controls.'></div>';
             }
-            if ($player->checkMedia($url) !== false)
+            if ($player->checkMedia($url) !== false || $player->checkExternalMp4($url) === true)
             {
 
                 if ($poster)


### PR DESCRIPTION
Es wurde eine Prüfung der URL auf externe MP4-Dateien eingebaut, sodass nun eine MP4-Datei nicht zwanghaft im Medienpool liegen muss, sondern auch von externen Quellen geladen werden kann.