### PR TITLE
Autoplay (muted), Loop, data-poster

### DIFF
--- a/lib/rex_plyr.php
+++ b/lib/rex_plyr.php
@@ -174,8 +174,11 @@ class rex_plyr
             $consent_content = $consent;
         }
         if ($controls) {
-            $player_conf = json_encode(explode(",", $controls));
+            $control_attr = explode(",", $controls);
+            $player_conf = json_encode($control_attr);
             $controls = ' data-plyr-config=\'{"controls":' . $player_conf . '}\'';
+            $autoplay = ($control_attr && in_array('autoplay', $control_attr)) ? ' autoplay muted' : '';
+            $loop = ($control_attr && in_array('loop', $control_attr)) ? ' loop' : '';
         }
 
         if ($player->checkYoutube($link) == true) {
@@ -186,11 +189,10 @@ class rex_plyr
         }
         if ($player->checkMedia($url) !== false || $player->checkExternalMp4($url) === true) {
             if ($poster) {
-                $poster = ' poster="' . $poster . '"';
+                $poster = ' data-poster="' . $poster . '"';
             }
-
             $out = '
-                        <video class="rex-plyr"' . $controls . ' playsinline volume=1' . $poster . '>
+                        <video class="rex-plyr"' . $controls . $autoplay . $loop .' playsinline volume=1' . $poster . '>
                             <source src="' . $link . '" type="video/mp4">
                         </video>
                     ';
@@ -198,7 +200,7 @@ class rex_plyr
 
         if ($player->checkAudio($url) !== false) {
             $out = '
-                        <audio class="rex-plyr"' . $controls . '>
+                        <audio class="rex-plyr"' . $controls . $autoplay . $loop . '>
                             <source src="' . $link . '" type="audio/mp3">
                         </audio>
                     ';


### PR DESCRIPTION
Autoplay  und Loop hinzugefügt. Autoplay liefert zwingend das Attribut "muted" mit (sonst Blocking durch Brwoser, siehe https://developers.google.com/web/updates/2017/09/autoplay-policy-changes
Aufruf: rex_plyr::outputMedia($video_file,'progress,airplay,pip,autoplay,loop', $poster_file);

Zweite Änderung:
Gemäß Vendor-Doku soll statt dem Attribut "poster" besser "data-poster" verwendet werden. => https://github.com/sampotts/plyr
"Note: The poster image should be specified using data-poster. This is to prevent it being downloaded twice. If you're sure the image will be cached, you can still use the poster attribute for true progressive enhancement."
Hab das mal mit angepasst - ist aber ungetestet (weil ich das nie verwende...)!