### PR TITLE
fix issue with conflicting event handlers for multiple players

### DIFF
--- a/assets/plyr_playlist.js
+++ b/assets/plyr_playlist.js
@@ -27,10 +27,10 @@ function loadPlaylist(players, player_id, myPlaylist) {
 
 	setTimeout(function () {}, 600);
 
-	$(document).on("click", "ul.plyr-playlist li a", function (event) {
+	$(document).on("click", "ul.plyr-playlist#playlist-"+ player_id +" li a", function (event) {
 		event.preventDefault();
 
-		$("li.pls-playing").removeClass("pls-playing");
+		$("ul.plyr-playlist#playlist-"+ player_id +" li.pls-playing").removeClass("pls-playing");
 		$(this)
 				.parent()
 				.addClass("pls-playing");


### PR DESCRIPTION
fix https://github.com/FriendsOfREDAXO/plyr/issues/54

An event handler was registered, that acted on all players. Upon click, it was wrongly executed on the first player, regardless which player instance was actually clicked upon.