### PR TITLE
Regex für "Vimeo Pro Direct Video Links" erweitert

### DIFF
--- a/lib/rex_plyr.php
+++ b/lib/rex_plyr.php
@@ -118,7 +118,7 @@ class rex_plyr
      */
     public static function checkVimeo($url)
     {
-        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/videos?)?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url)) {
+        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url)) {
             return true;
         }
         return false;
@@ -132,8 +132,8 @@ class rex_plyr
     public static function getVimeoId($url)
     {
         $vimeoID = "";
-        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/videos?)?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url, $match)) {
-            $vimeoID = $match[1];
+        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url, $match)) {
+            $vimeoID = $match[2];
         }
         return $vimeoID;
     }


### PR DESCRIPTION
Ich habe die Regex für die Erkennung von gültigen Vimeo URLs / iframes so erweitert, damit auch Vimeo "Direct video links" zu erkennen.  Das ist ein Vimeo Pro Feature. 
Die URLs sehen wie folgt aus:

- https://player.vimeo.com/external/563188771.hd.mp4?s=15d954ee0de3932df3f57608355868c0c4e05bd4&profile_id=175

Doku bei Vimeo zu dem Feature:
https://vimeo.zendesk.com/hc/en-us/articles/224823567