### PR TITLE
Für neue Vimeo URLs angepasst

### DIFF
--- a/lib/rex_plyr.php
+++ b/lib/rex_plyr.php
@@ -118,7 +118,7 @@ class rex_plyr
      */
     public static function checkVimeo($url)
     {
-        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url)) {
+        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(progressive_redirect\/playback|external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url)) {
             return true;
         }
         return false;
@@ -132,7 +132,7 @@ class rex_plyr
     public static function getVimeoId($url)
     {
         $vimeoID = "";
-        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url, $match)) {
+        if (preg_match('~(?:<iframe [^>]*src=")?(?:https?:\/\/(?:[\w]+\.)*vimeo\.com(?:[\/\w]*\/(progressive_redirect\/playback|external|videos?))?\/([0-9]+)[^\s]*)"?(?:[^>]*></iframe>)?(?:<p>.*</p>)?~ix', $url, $match)) {
             $vimeoID = $match[2];
         }
         return $vimeoID;


### PR DESCRIPTION
Vimeo hat mal wieder die URLs zu den Videos ohne Player geändert. Die neuen URLs sehen jetzt so aus:

https://player.vimeo.com/progressive_redirect/playback/663286166/rendition/1080p/file.mp4?loc=external&signature=9a6f5d65e45d0388e7d26e4217083748324feba0b5caf57d049169f946e76bcd